### PR TITLE
Compile with GCC/Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,46 @@
+C = gcc
+CPP = g++
+CFLAGS = -Wall
+# These CPP flags may need adjustment, especially hardcoded paths...
+CPPFLAGS = -fPIC -I/usr/include/python2.7 -I../../sti/device/include
+ALL = MixedValuePy.o ORBManagerPy.o PartnerDevicePy.o RawEventPy.o STI_Device_Adapter_Pub.o STI_Device_Adapter_Wrapper.o SynchronousEventAdapterPub.o SynchronousEventAdapterPy.o STIDevicePy.o STIPy.so python/STIPy.so
+
+all: $(ALL) 
+
+MixedValuePy.o: MixedValuePy.cpp
+	$(CPP) $(CPPFLAGS) -c MixedValuePy.cpp
+
+ORBManagerPy.o: ORBManagerPy.cpp
+	$(CPP) $(CPPFLAGS) -c ORBManagerPy.cpp
+
+PartnerDevicePy.o: PartnerDevicePy.cpp
+	$(CPP) $(CPPFLAGS) -c PartnerDevicePy.cpp
+
+RawEventPy.o: RawEventPy.cpp
+	$(CPP) $(CPPFLAGS) -c RawEventPy.cpp
+
+STI_Device_Adapter_Pub.o: STI_Device_Adapter_Pub.cpp
+	$(CPP) $(CPPFLAGS) -c STI_Device_Adapter_Pub.cpp
+
+STI_Device_Adapter_Wrapper.o: STI_Device_Adapter_Wrapper.cpp
+	$(CPP) $(CPPFLAGS) -c STI_Device_Adapter_Wrapper.cpp
+
+SynchronousEventAdapterPub.o: SynchronousEventAdapterPub.cpp
+	$(CPP) $(CPPFLAGS) -c SynchronousEventAdapterPub.cpp
+
+SynchronousEventAdapterPy.o: SynchronousEventAdapterPy.cpp
+	$(CPP) $(CPPFLAGS) -c SynchronousEventAdapterPy.cpp
+
+STIDevicePy.o: STIDevicePy.cpp
+	$(CPP) $(CPPFLAGS) -c STIDevicePy.cpp
+
+STIPy.so: MixedValuePy.o ORBManagerPy.o PartnerDevicePy.o RawEventPy.o STI_Device_Adapter_Pub.o STI_Device_Adapter_Wrapper.o SynchronousEventAdapterPub.o SynchronousEventAdapterPy.o STIDevicePy.o
+	$(CPP) -shared *.o ../../sti/device/src/libcorba.a -lboost_python -lxerces-c -lomniORB4 -lboost_thread -lboost_filesystem -o STIPy.so
+
+python/STIPy.so:
+	(cd python; ln -s ../STIPy.so ./)
+	
+clean:
+	rm $(ALL)
+
+

--- a/src/STI_Device_Adapter_Pub.cpp
+++ b/src/STI_Device_Adapter_Pub.cpp
@@ -176,7 +176,7 @@ void STI_Device_Adapter_Pub::convertRawEventMap(const RawEventMap& eventsIn, boo
 	}
 }
 
-void STI_Device_Adapter_Pub::parseDeviceEvents(const RawEventMap& eventsIn, SynchronousEventVector& eventsOut)
+void STI_Device_Adapter_Pub::parseDeviceEvents(const RawEventMap& eventsIn, SynchronousEventVector& eventsOut) throw (std::exception)
 {
 	//also see:  https://stackoverflow.com/questions/6157409/stdvector-to-boostpythonlist
 	

--- a/src/STI_Device_Adapter_Pub.h
+++ b/src/STI_Device_Adapter_Pub.h
@@ -47,7 +47,7 @@ public:
 	virtual std::string execute(int argc, char* argv[]);
 
 	// Device-specific event parsing
-	virtual void parseDeviceEvents(const RawEventMap& eventsIn, SynchronousEventVector& eventsOut);
+	virtual void parseDeviceEvents(const RawEventMap& eventsIn, SynchronousEventVector& eventsOut) throw (std::exception);
 	virtual void parseDeviceEvents_py(const boost::python::list& eventsIn, boost::python::list& eventsOut);
 
 	// Event Playback control

--- a/src/python/thread_mwe.py
+++ b/src/python/thread_mwe.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python2.7
+#!/usr/bin/env python2.7
 import STIPy, threading, time
 
 # Choose what to thread. Similar/same behavior for all interesting cases.
@@ -24,7 +24,7 @@ class MyDevice(STIPy.STI_Device):
             dataOut.addValue(self.counter)
         else: # ...so, this must be a local read
             print("%s read from Python" % (self.counter,))
-        #self.counter += 1
+        self.counter += 1
         self.lock.release()
         return True
 
@@ -36,7 +36,6 @@ class MyDevice(STIPy.STI_Device):
 def localStuff(dev):
     while True:
         time.sleep(2); # Don't just hammer STI server...
-        dev.counter += 1
         dev.readChannel(0, [], [])
 
 


### PR DESCRIPTION
Near-minimum required changes for compatibility with my box (and presumably any GCC-based system):

- Added Makefile (very simple)
- Added throw(...) to STI_Device_Adapter_Pub::parseDeviceEvents (compilation fails with error otherwise)
- Removed BOM from Python script (your editor doesn't play nice with others...), changed counter behavior for testing purposes.